### PR TITLE
corrgindo bug de continuidade do minigame

### DIFF
--- a/scripts/HUD/genericPopup.gd
+++ b/scripts/HUD/genericPopup.gd
@@ -11,6 +11,7 @@ func _ready():
 	label.text = "Parabens! Voce venceu o quebra cabeça. Continue para desvendar mais mistérios do arquipelago e salva-lo da extinção."
 
 func onButtonPressed() -> void:
+	get_tree().current_scene.queue_free()
 	get_tree().change_scene_to_file(GameState.lastMapPath)
 	queue_free()
 

--- a/scripts/gameState.gd
+++ b/scripts/gameState.gd
@@ -18,7 +18,7 @@ var isDark: bool = false
 #inventario
 var actionBarTextures: Array = [null, null, null, null, null]
 var actionBarNames: Array = ["nada", "nada", "nada", "nada", "nada"]
-var selectedItem: String = "starFruit"
+var selectedItem: String = ""
 
 #control variables
 var executeFirst: bool = true

--- a/scripts/minigames/fruitGame.gd
+++ b/scripts/minigames/fruitGame.gd
@@ -5,15 +5,14 @@ extends Node2D
 @export var fruit: String = "grubble"
 
 const speed: float = 60.0
-const maxSpeed: float = 300.0
+const maxSpeed: float = 200.0
 
 func _ready() -> void:
 	anim.play(fruit)
 	button.pressed.connect(changeFruit)	
 
 func _process(delta: float) -> void:
-	var bonusSpeed = GameState.bonusSpeed
-	var actualSpeed = (speed + bonusSpeed) * delta
+	var actualSpeed = (speed + GameState.bonusSpeed) * delta
 	position.y += min(actualSpeed, maxSpeed)
 	
 	if position.y >= 500.0:

--- a/scripts/minigames/trashGame.gd
+++ b/scripts/minigames/trashGame.gd
@@ -3,15 +3,16 @@ extends Node2D
 @onready var button: TextureButton = $trashButton
 @onready var anim: AnimatedSprite2D = $trashCan
 @export var trash: String = "can"
-@export var speed: float = 60.0
+const speed: float = 60.0
+const maxSpeed: float = 200.0
 
 func _ready() -> void:
 	anim.play(trash)
 	button.pressed.connect(changeTrash)
 
 func _process(delta: float) -> void:
-	var bonusSpeed: float = GameState.bonusSpeed
-	position.y += (speed + bonusSpeed) * delta
+	var actualSpeed = (speed + GameState.bonusSpeed) * delta
+	position.y += min(actualSpeed, maxSpeed)
 	
 	if position.y >= 500.0:
 		queue_free()

--- a/scripts/minigames/trashHunterGame.gd
+++ b/scripts/minigames/trashHunterGame.gd
@@ -13,10 +13,12 @@ var trashs = ["bottle", "can", "hook", "straw"]
 
 func _ready() -> void:
 	GameState.setScore(0)
+	GameState.gameTime = 120
+	GameState.bonusSpeed = 0
 
 func _process(delta: float) -> void:
 	scoreLabel.text = str(GameState.getScore())
-	GameState.bonusSpeed += delta * 5
+	GameState.bonusSpeed += delta * 4
 
 	if GameState.getScore() >= 50:
 		endGame()
@@ -56,7 +58,6 @@ func onTimerGameTimeout() -> void:
 	timerLabel.text = str(GameState.gameTime/60)+":"+str(GameState.gameTime%60)
 	if GameState.gameTime == 0:
 		GameState.beatThirdPuzzle = false
-		GameState.setScore(0)
 		get_tree().set_pause(true)
 		var popup = genericScene.instantiate()
 		get_tree().root.add_child(popup)


### PR DESCRIPTION
corrigindo comportamento inesperado em que ao perder pela primeira vez no minigame salada de frutas e fazer uma nova tentativa, o progresso anterior nao foi apagado, e isso faz com que o cronometro do jogo e a pontuaçao ficassem negativas, alem de manter a velocidade alta dos itens caindo. Tambem foi diminuida um pouco a velocidade maxima dos itens cairem para facilitar um pouco mais o jogo.